### PR TITLE
Server#attached_volumes fixed

### DIFF
--- a/lib/fog/profitbricks/parsers/compute/get_all_servers.rb
+++ b/lib/fog/profitbricks/parsers/compute/get_all_servers.rb
@@ -37,6 +37,7 @@ module Fog
               @storage['size'] = value.to_i
             when 'connectedStorages'
               @server['connectedStorages'] << @storage
+              @storage = {}
             when 'nicId', 'nicName', 'macAddress', 'gatewayIp',
                'dhcpActive', 'ips'
               @nic[name] = value

--- a/lib/fog/profitbricks/parsers/compute/get_server.rb
+++ b/lib/fog/profitbricks/parsers/compute/get_server.rb
@@ -39,6 +39,7 @@ module Fog
               @storage['size'] = value.to_i
             when 'connectedStorages'
               @response['getServerResponse']['connectedStorages'] << @storage
+              @storage = {}
             when 'nicId', 'nicName', 'macAddress', 'gatewayIp',
                'dhcpActive', 'ips'
               @nic[name] = value


### PR DESCRIPTION
If a server has multiple volumes, then the method attached_volumes returns an array with the same values.

Example:
compute.servers.get('server-id').attached_volumes
[
{"boot_device"=>"true", "bus_type"=>"VIRTIO", "device_number"=>1, "size"=>8, "id"=>"volume-id", "name"=>"name"}, 
{"boot_device"=>"true", "bus_type"=>"VIRTIO", "device_number"=>1, "size"=>8, "id"=>"volume-id", "name"=>"name"}, 
{"boot_device"=>"true", "bus_type"=>"VIRTIO", "device_number"=>1, "size"=>8, "id"=>"volume-id", "name"=>"name"}
]

Because the storage hash is only created once and will be updated for each storage!
This patch will create a new storage hash for each storage, after the storage is added!
[
{"boot_device"=>"false", "bus_type"=>"VIRTIO", "device_number"=>2, "size"=>85, "id"=>"volume-id-2", "name"=>"name-2"}, 
{"boot_device"=>"true", "bus_type"=>"VIRTIO", "device_number"=>1, "size"=>10, "id"=>"volume-id-1", "name"=>"root"}, 
{"boot_device"=>"false", "bus_type"=>"VIRTIO", "device_number"=>3, "size"=>2, "id"=>"volume-id-3", "name"=>"name-3"}
]