### PR TITLE
Added rubocop back to gemspec

### DIFF
--- a/fog-profitbricks.gemspec
+++ b/fog-profitbricks.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "shindo", "~> 0.3"
   spec.add_development_dependency "turn", "~> 0.9"
   spec.add_development_dependency "pry", "~> 0.10"
+  spec.add_development_dependency "rubocop" if RUBY_VERSION >= "2.0.0"
 end


### PR DESCRIPTION
I had to set the rubocop dependency requirement to Ruby 2.0.0 to achieve successful tests.